### PR TITLE
CLC-6055 Log failed and unparseable SAML responses

### DIFF
--- a/lib/omniauth/strategies/cas/saml_ticket_validator.rb
+++ b/lib/omniauth/strategies/cas/saml_ticket_validator.rb
@@ -41,8 +41,12 @@ module OmniAuth
             if success?(doc)
               attrs = extract_attributes(doc)
               { "user" => attrs["uid"] }.merge(attrs)
+            else
+              OmniAuth.logger.warn "Received unsuccessful SAML response, will return nil user_info:\n#{@response_body}"
+              nil
             end
           rescue Nokogiri::XML::XPath::SyntaxError
+            OmniAuth.logger.warn "Could not parse SAML response, will return nil user_info:\n#{@response_body}"
             nil
           end
         end


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6055

This cautious PR will not stop omniauth-cas errors from being thrown, but will log the full SAML response  for the error-triggering condition.
