### PR TITLE
CLC-6100 Use empty hash, not nil, for user info from invalid tickets

### DIFF
--- a/lib/omniauth/strategies/cas.rb
+++ b/lib/omniauth/strategies/cas.rb
@@ -206,7 +206,7 @@ module OmniAuth
       def fetch_raw_info(ticket)
         ticket_user_info = validate_service_ticket(ticket).user_info
         custom_user_info = options.fetch_raw_info.call(self, options, ticket, ticket_user_info)
-        self.raw_info = ticket_user_info.merge(custom_user_info)
+        self.raw_info = (ticket_user_info || {}).merge(custom_user_info)
       end
 
       # Deletes Hash pairs with `nil` values.


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/CLC-6100

In omniauth-cas-world, an empty `raw_info` hash signifies failure:

https://github.com/ets-berkeley-edu/omniauth-cas/blob/master/lib/omniauth/strategies/cas.rb#L88

But the new SAML-ticket validator may parse so as to return nil instead of empty on failure. Avoid a blowup and raise the intended error.
