### PR TITLE
SISRP-33210 - Add NameIdentifier to source UID for Omniauth-Cas Strategy

### DIFF
--- a/lib/omniauth/strategies/cas/saml_ticket_validator.rb
+++ b/lib/omniauth/strategies/cas/saml_ticket_validator.rb
@@ -40,6 +40,7 @@ module OmniAuth
             doc.remove_namespaces!
             if success?(doc)
               attrs = extract_attributes(doc)
+              attrs["nameIdentifier"] = extract_name_identifier(doc)
               { "user" => attrs["uid"] }.merge(attrs)
             else
               OmniAuth.logger.warn "Received unsuccessful SAML response, will return nil user_info:\n#{@response_body}"
@@ -62,6 +63,10 @@ module OmniAuth
             attrs[node.attr("AttributeName")] = node.css("AttributeValue").text
             attrs
           end
+        end
+
+        def extract_name_identifier(doc)
+          doc.css("AuthenticationStatement Subject NameIdentifier").text
         end
 
         def saml_payload


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-33210

* Traverses SAML response for <NameIdentifier> node, and adds it to the attributes passed back via `omniauth.auth`
* This will allow us to authenticate via CAS for the new BCS92TST environment, which bypasses attributes.