### PR TITLE
SISRP-42655: Update required omniauth version to ~> 1.3.2

### DIFF
--- a/omniauth-cas.gemspec
+++ b/omniauth-cas.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Omniauth::Cas::VERSION
 
-  gem.add_dependency 'omniauth',                '~> 1.2.0'
+  gem.add_dependency 'omniauth',                '~> 1.3.2'
   gem.add_dependency 'nokogiri',                '~> 1.5'
   gem.add_dependency 'addressable',             '~> 2.3'
 


### PR DESCRIPTION
Addresses CVE-2017-18076: https://nvd.nist.gov/vuln/detail/CVE-2017-18076